### PR TITLE
Use lubridate to display a gameDateFormatted column which will display the start of the game using the local date and time.

### DIFF
--- a/examples/R-lang/National Hockey League - NHL/NHL API - Example to view data for a specific NHL game ID/NHL-API-view-data-for-a-specific-game-id.R
+++ b/examples/R-lang/National Hockey League - NHL/NHL API - Example to view data for a specific NHL game ID/NHL-API-view-data-for-a-specific-game-id.R
@@ -4,6 +4,7 @@
 # install.packages("dplyr")    # The %>% is no longer natively supported by the R language
 # install.packages("tibble")
 # install.packages("tidyr")
+# install.packages("lubridate")
 
 # Loading packages
 library(httr)
@@ -11,6 +12,7 @@ library(jsonlite)
 library(dplyr)
 library(tibble)
 library(tidyr)
+library(lubridate)
 
 
 try(
@@ -66,8 +68,17 @@ try(
         linescore.currentPeriodTimeRemaining,
         NA
       )) %>%
+      # ymd_hms is used to convert the gameDate column in the dataframe to a date-time object
+      mutate(gameDate = ymd_hms(gameDate)) %>% # 2023-05-13 02:00:00
+      mutate(gameDateFormatted = format(
+        # with_tz is used to convert the date-time object to the local time zone - which is "America/Los_Angeles" for Seattle WA
+        with_tz(gameDate, Sys.timezone()),
+        # format is used to format the date-time object to the desired output format ("%Y-%m-%d %I:%M%p %Z") which gives the date and time in the format "YYYY-MM-DD hh:mmAM/PM Timezone"
+        # %I will display a twelve-hour time value with a leading zero. In this case, I want to use %l so we see the desired value
+        format = "%Y-%m-%d %l:%M %p %Z" # 2023-05-12  7:00 PM PDT
+      )) %>%
       select(
-        gamePk, gameDate,
+        gamePk, gameDate, gameDateFormatted,
         away.team.name, away.score,
         home.team.name, home.score,
         currentPeriodOrdinal,


### PR DESCRIPTION
This PR adds a friendlier display of game times. We want to take `gameDate` (example value of `2023-05-13 02:00:00`) and have it be presented in a new `gameDateFormatted` column using local time (example value of `2023-05-12  7:00 PM PDT`)

Before
![Screenshot 2023-05-12 at 2 55 33 PM](https://github.com/TheRobBrennan/explore-nhl-api-with-r-and-python/assets/4030490/47e8bbc4-6745-4437-90a8-906c63d99f0e)

After
![Screenshot 2023-05-12 at 3 31 08 PM](https://github.com/TheRobBrennan/explore-nhl-api-with-r-and-python/assets/4030490/5c69a13c-245c-4f39-97a9-6cf05736977b)
